### PR TITLE
Don't store socialaccount token in sign up process

### DIFF
--- a/django_toyo_auth/signals.py
+++ b/django_toyo_auth/signals.py
@@ -1,13 +1,12 @@
 from django.dispatch import receiver
 from allauth.account.signals import user_signed_up
 from allauth.socialaccount.signals import social_account_added, social_account_updated, social_account_removed
-from allauth.socialaccount.models import SocialAccount, SocialToken
-import re
+from allauth.socialaccount.models import SocialAccount
+
 
 @receiver(user_signed_up)
 def signed_up(user, **kwargs):
     social_info = SocialAccount.objects.filter(user=user)[0]
-    social_token = SocialToken.objects.filter(account=social_info)[0]
     if social_info.provider in ["iniad", "toyo"]:
         user.is_student = social_info.extra_data["is_student"]
         if not user.is_toyo_member:
@@ -18,11 +17,11 @@ def signed_up(user, **kwargs):
         user.entry_year = social_info.extra_data["entry_year"]
         user.save()
 
+
 @receiver(social_account_added)
 def account_added(request, sociallogin, **kwargs):
     user = request.user
     social_info = sociallogin.account
-    social_token = sociallogin.token
     if social_info.provider in ["iniad", "toyo"]:
         user.is_student = social_info.extra_data["is_student"]
         if not user.is_toyo_member:


### PR DESCRIPTION
## 概要
django-allauth は v0.84（[リリースノート](https://github.com/pennersr/django-allauth/blob/master/ChangeLog.rst#0480-2022-02-03)） から socialaccount token の保存をデフォルトで行わないような変更を行った。  
保存を行うには`SOCIALACCOUNT_STORE_TOKENS`を`True`に設定すれば可能だが、トークンはセンシティブなものであり、必要以上の情報を得ることは望ましくないので、socialaccount token が関わる部分を削除することが適当であると思う。